### PR TITLE
Delayed restarts

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -108,7 +108,7 @@ function calculateDelay() {
     }
     
     deaths.splice(index, 1);
-    return false;
+    return 0;
   }));
   
   if (delay === interval) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/namshi/clusterjs",
   "dependencies": {
+    "lodash": "^3.6.0",
     "yargs": "^1.2.6"
   }
 }


### PR DESCRIPTION
Introducing a new logic to be able to delay a restart of the workers:
for every worker that dies in the past 10s we wait 250ms (we should make)
this configurable, but let's go ahead with this stuff -- at least to test
it?

If there was only 1 death in the past 10s we do not actually delay
the process of booting a new worker, as it might have been a genuine
death caused by whatever problem. This means we only delay when workers
are dying in series, maybe due to a networking problem or simply because
they can't boot for whatever reason.

What this solves is the fact that clusterjs keeps trying to reboot stuff, thus consuming all CPU on the machine it runs on.

Supervisor uses a different approach, with [startRetries](http://supervisord.org/configuration.html),
though the problem there is that at one point, if the application can't
temporarely boot, it stays down forever.

Comments are welcome :)

/cc @unlucio @cirpo 
